### PR TITLE
Query string retention for target URLs which already contain query string

### DIFF
--- a/RedirectsProcessor.php
+++ b/RedirectsProcessor.php
@@ -139,7 +139,9 @@ class RedirectsProcessor
         }
 
         if ($redirect->isRetainQueryStrings() && $request->getQueryString()) {
-            $redirectUrl .= '?' . $request->getQueryString();
+            // If redirect target already contains a query string, concat additional query string with `&`, otherwise default to `?`
+            $redirectUrl .= (strpos($redirectUrl, '?') !== false) ? '&' : '?';
+            $redirectUrl .= $request->getQueryString();
         }
 
         if ($this->shouldLogRedirect()) {


### PR DESCRIPTION
Hey! 

We had the issue that we wanted to redirect to a target URL which contained a query string (Example: `/redirect-target?foo=bar`)

In the code I check if there is already a `?` in the target URL and concat the retained query string from the source URL with an `&`.

Thank you for you work on the plugin! 

Philipp